### PR TITLE
libraries update - php8.3 added, actions/checkout updated, codeception/lib-innerbrowser updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
 
     steps:
       - name: Set up PHP
@@ -20,7 +20,7 @@ jobs:
           tools: composer:v2
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download dependencies
         run: composer update --no-interaction --prefer-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
 
       - name: Download dependencies
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
 
       - name: Download dependencies
@@ -55,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
 
       - name: Download dependencies

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- PHP 8.3 support
+- codeception/lib-innerbrowser ^4.0 support
+
 ## [4.1.0] - 2023-03-17
 ### Added
 - PHP 8.2 support

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,4 @@ local-ci:
 	$(DOCKER_RUN) php:8.0-cli vendor/bin/codecept run
 	$(DOCKER_RUN) php:8.1-cli vendor/bin/codecept run
 	$(DOCKER_RUN) php:8.2-cli vendor/bin/codecept run
+	$(DOCKER_RUN) php:8.3-cli vendor/bin/codecept run

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspiration comes from [herloct/codeception-slim-module](https://github.com/herl
 ## Install
 
 ### Minimal requirements
-- php: `^8.1`
+- php: `^8.0`
 - slim/slim: `^4.7`
 - codeception/codeception: `^5.0`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspiration comes from [herloct/codeception-slim-module](https://github.com/herl
 ## Install
 
 ### Minimal requirements
-- php: `^8.0`
+- php: `^8.1`
 - slim/slim: `^4.7`
 - codeception/codeception: `^5.0`
 

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "codeception/codeception": "^5.0",
-        "codeception/lib-innerbrowser": "^3.0",
+        "codeception/lib-innerbrowser": "^4.0",
         "slim/psr7": "^1.3",
         "slim/slim": "^4.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "codeception/codeception": "^5.0",
-        "codeception/lib-innerbrowser": "^4.0",
+        "codeception/lib-innerbrowser": "^3.0 || ^4.0",
         "slim/psr7": "^1.3",
         "slim/slim": "^4.7"
     },

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "php": "^8.0",
+        "php": "^8.1",
         "friendsofphp/php-cs-fixer": "^3.15"
     },
     "config": {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "php": "^8.0",
+        "php": "^8.1",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^1.1"
     },

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "php": "^8.0",
+        "php": "^8.1",
         "psalm/phar": "^5.8"
     },
     "config": {


### PR DESCRIPTION
    lib update actions/checkout to use v4
    dropped php8.0 support
    added php8.3 support
    lib update: codeception/lib-innerbrowser version ^4.0

All tests are passing ok without another source code changes.
Php8.0 didn't work with some lib update, but it isn't supported by php anyway.

(It could be just fine for me to make the new release version with these changes.)